### PR TITLE
docs: Fix import Client command

### DIFF
--- a/fern/pages/getting_started.mdx
+++ b/fern/pages/getting_started.mdx
@@ -272,7 +272,7 @@ git checkout release/0.0.34
 Or you can simply modify you code to change the import stream as follows:
 
 ```python
-from label_studio_sdk._legacy import Client
+from label_studio_sdk import Client
 from label_studio_sdk.data_manager import Filters, Column, Operator, Type
 from label_studio_sdk._legacy import Project
 ```


### PR DESCRIPTION
Getting started section on using legacy SDK had an error. 

`from label_studio_sdk._legacy import Client`
-->
`from label_studio_sdk import Client`