### PR TITLE
chore: Bump NLTK to ^3.9.1

### DIFF
--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -38,7 +38,7 @@ groups:
             pandas: '>=0.24.0'
             requests: '>=2.22.0'
             Pillow: '>=10.0.1'
-            nltk: '^3.8.1'
+            nltk: '^3.9.1'
             ujson: '>=5.8.0'
             ijson: '>=3.2.3'
             appdirs: '>=1.4.3'


### PR DESCRIPTION
Upgrading the minimum version of NLTK required in the sdk since 3.8.1 is affected by a CVE: https://github.com/nltk/nltk/issues/3266