### PR TITLE
feat: DIA-1402: V1-Submit Prompt auto-refinement job

### DIFF
--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -16,7 +16,7 @@ groups:
           package-name: label-studio-sdk
         github:
           repository: HumanSignal/label-studio-sdk
-          # Branch will be automatically replaced during Follow Merge
+          # Branch and Mode will be automatically replaced during Follow Merge
 #          branch: fern-bot/08-05-2024-0231PM
 #          mode: push
           mode: pull-request

--- a/fern/openapi/overrides.yaml
+++ b/fern/openapi/overrides.yaml
@@ -77,7 +77,7 @@ paths:
       x-fern-audiences:
         - public
 
-  /api/prompts/{id}/versions/{version_id}/refine-prompt:
+  /api/prompts/{prompt_id}/versions/{version_id}/refine-prompt:
     post:
       $ref: "./resources/prompts.yaml#/paths/~1api~1prompts~1{id}~1versions~1{version_id}~1refine-prompt/post"
       x-fern-sdk-group-name:

--- a/fern/openapi/overrides.yaml
+++ b/fern/openapi/overrides.yaml
@@ -79,7 +79,7 @@ paths:
 
   /api/prompts/{prompt_id}/versions/{version_id}/refine-prompt:
     post:
-      $ref: "./resources/prompts.yaml#/paths/~1api~1prompts~1{id}~1versions~1{version_id}~1refine-prompt/post"
+      $ref: "./resources/prompts.yaml#/paths/~1api~1prompts~1{prompt_id}~1versions~1{version_id}~1refine-prompt/post"
       x-fern-sdk-group-name:
         - prompts
         - versions

--- a/fern/openapi/overrides.yaml
+++ b/fern/openapi/overrides.yaml
@@ -77,9 +77,9 @@ paths:
       x-fern-audiences:
         - public
 
-  /api/prompts/{prompt_id}/versions/{version_id}/refine-prompt:
+  /api/prompts/{prompt_id}/versions/{version_id}/refine:
     post:
-      $ref: "./resources/prompts.yaml#/paths/~1api~1prompts~1{prompt_id}~1versions~1{version_id}~1refine-prompt/post"
+      $ref: "./resources/prompts.yaml#/paths/~1api~1prompts~1{prompt_id}~1versions~1{version_id}~1refine/post"
       x-fern-sdk-group-name:
         - prompts
         - versions

--- a/fern/openapi/overrides.yaml
+++ b/fern/openapi/overrides.yaml
@@ -77,6 +77,16 @@ paths:
       x-fern-audiences:
         - public
 
+  /api/prompts/{id}/versions/{version_id}/refine-prompt:
+    post:
+      $ref: "./resources/prompts.yaml#/paths/~1api~1prompts~1{id}~1versions~1{version_id}~1refine-prompt/post"
+      x-fern-sdk-group-name:
+        - prompts
+        - versions
+      x-fern-sdk-method-name: refine_prompt
+      x-fern-audiences:
+        - public
+
   /api/prompts/{id}/versions/{version_id}/inference-runs:
     get:
       $ref: "./resources/prompts.yaml#/paths/~1api~1prompts~1{id}~1versions~1{version_id}~1inference-runs/get"

--- a/fern/openapi/resources/prompts.yaml
+++ b/fern/openapi/resources/prompts.yaml
@@ -280,7 +280,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/InferenceRun"
 
-  /api/prompts/{prompt_id}/versions/{version_id}/refine-prompt:
+  /api/prompts/{prompt_id}/versions/{version_id}/refine:
     post:
       summary: Refine a prompt version
       description: >

--- a/fern/openapi/resources/prompts.yaml
+++ b/fern/openapi/resources/prompts.yaml
@@ -292,7 +292,7 @@ paths:
           required: true
           schema:
             type: integer
-        - name: base_model_version_id
+        - name: version_id
           in: path
           description: Base Prompt Version ID
           required: true

--- a/fern/openapi/resources/prompts.yaml
+++ b/fern/openapi/resources/prompts.yaml
@@ -292,7 +292,7 @@ paths:
           required: true
           schema:
             type: integer
-        - name: version_id
+        - name: base_model_version_id
           in: path
           description: Base Prompt Version ID
           required: true

--- a/fern/openapi/resources/prompts.yaml
+++ b/fern/openapi/resources/prompts.yaml
@@ -280,19 +280,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/InferenceRun"
 
-  /api/prompts/{id}/versions/{version_id}/refine-prompt:
+  /api/prompts/{prompt_id}/versions/{version_id}/refine-prompt:
     post:
       summary: Refine a prompt version
       description: >
         Refine a prompt version using a teacher model and save the refined prompt as a new version.
       parameters:
-        - name: id
+        - name: prompt_id
           in: path
           description: Prompt ID
           required: true
           schema:
             type: integer
-          x-fern-ignore-in-client: true  # not used in the api
         - name: version_id
           in: path
           description: Base Prompt Version ID

--- a/fern/openapi/resources/prompts.yaml
+++ b/fern/openapi/resources/prompts.yaml
@@ -286,6 +286,12 @@ paths:
       description: >
         Refine a prompt version using a teacher model and save the refined prompt as a new version.
       parameters:
+        - name: id
+          in: path
+          description: Prompt ID
+          required: true
+          schema:
+            type: integer
         - name: version_id
           in: path
           description: Base Prompt Version ID

--- a/fern/openapi/resources/prompts.yaml
+++ b/fern/openapi/resources/prompts.yaml
@@ -747,7 +747,7 @@ components:
                       description: Error message details
                   additionalProperties:
                     nullable: true
-    api_prompts_version_refine_prompt_create:
+    api_prompts_versions_refine_prompt_create:
       content:
         application/json:
           schema:

--- a/fern/openapi/resources/prompts.yaml
+++ b/fern/openapi/resources/prompts.yaml
@@ -292,6 +292,7 @@ paths:
           required: true
           schema:
             type: integer
+          x-fern-ignore-in-client: true  # not used in the api
         - name: version_id
           in: path
           description: Base Prompt Version ID

--- a/fern/openapi/resources/prompts.yaml
+++ b/fern/openapi/resources/prompts.yaml
@@ -280,6 +280,27 @@ paths:
               schema:
                 $ref: "#/components/schemas/InferenceRun"
 
+  /api/prompts/{id}/versions/{version_id}/refine-prompt:
+    post:
+      summary: Refine a prompt version
+      description: >
+        Refine a prompt version using a teacher model and save the refined prompt as a new version.
+      parameters:
+        - name: version_id
+          in: path
+          description: Base Prompt Version ID
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        $ref: "#/components/requestBodies/api_prompts_versions_refine_prompt_create"
+      responses:
+        "201":
+          description: ""
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PromptVersion"
   /api/inference-runs/{pk}/indicators:
     get:
       summary: Get key indicators
@@ -726,3 +747,23 @@ components:
                       description: Error message details
                   additionalProperties:
                     nullable: true
+    api_prompts_version_refine_prompt_create:
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:  # TODO need to add model version from url here?
+              teacher_model_provider_connection_id:
+                title: Teacher Model Provider Connection ID
+                description: Model Provider Connection ID to use to refine the prompt
+                type: integer
+              teacher_model_name:
+                title: Teacher Model Name
+                description: Name of the model to use to refine the prompt
+                type: string
+                additionalProperties:
+                  nullable: true
+              project_id:
+                title: Project ID
+                description: Project ID to target the refined prompt for
+                type: integer


### PR DESCRIPTION
Plan for autorefinement:
```
# this PR - DIA-1402/1407
# makes a single api call to the teacher model and returns the new prompt version immediately
# can extend in future to update the current prompt version using PATCH instead of POST
# other parameters: teacher model provider connection id, teacher model name, project id
/api/prompts/{id}/versions/{version_id}/refine-prompt

# autorefinement using ground truth data
# creates a new "run" object analogous to an InferenceRun, the new or updated prompt version and new inference runs are available when the RefinementRun completes
# same parameters: teacher model provider connection id, teacher model name, project id
# manage state the same way as with InferenceRuns using polling, or try something new like websockets?
/api/prompts/{id}/versions/{version_id}/refinement-runs/{run_id}

# create a prompt version with the "prompt" field already filled in
# extend existing create endpoint
# parameters: optional[teacher model provider connection id, teacher model name], optional[project id]
# if teacher provided, ask it for a good prompt given the skill
# if project id provided, enrich the teacher info with example tasks from the project
# if optional params not provided, "prompt" field can still be null - fallback to a generic string template using skill name and input fields
POST /api/prompts/{id}/versions/
```