### PR TITLE
feat: LEAP-1782: add pauses to members list

### DIFF
--- a/fern/openapi/resources/pauses.yaml
+++ b/fern/openapi/resources/pauses.yaml
@@ -164,7 +164,12 @@ components:
           type: integer
         paused_by:
           title: Paused By
-          type: integer
+          description: User who created the pause
+          anyOf:
+            - type: integer
+            - type: object
+          nullable: true
+          readOnly: true
         reason:
           title: Reason
           type: string
@@ -206,4 +211,3 @@ components:
                 nullable: true
             required:
               - reason
-


### PR DESCRIPTION
paused_by returns an object (minimal user representation)