### PR TITLE
fix: `anyOf` type for `Annotation.created_by`

### DIFF
--- a/fern/openapi/openapi.yaml
+++ b/fern/openapi/openapi.yaml
@@ -7653,7 +7653,9 @@ components:
           minLength: 1
         completed_by:
           title: Completed by
-          type: integer
+          anyOf:
+            - $ref: "#/components/schemas/UserSimple"
+            - integer
         unique_id:
           title: Unique id
           type: string


### PR DESCRIPTION
[Reference PR](https://github.com/HumanSignal/label-studio-sdk/pull/420)

I _think_ that from what I found this would be the correct change to make for resolving the issue cited in the referenced PR. From what I can tell, the `/api/tasks/{id}/` uses the [`AnnotationsDmField.completed_by` definition](https://github.com/HumanSignal/label-studio-sdk/blob/cc36df837aa4db768dc32e899f41fa0be967f6ec/src/label_studio_sdk/types/annotations_dm_field.py#L28), with that field's type defined in the API spec [here](https://github.com/HumanSignal/label-studio-client-generator/blob/474228b0171c5723ee418b240ac620f8a0b1121c/fern/openapi/openapi.yaml#L10112):

https://github.com/HumanSignal/label-studio-client-generator/blob/474228b0171c5723ee418b240ac620f8a0b1121c/fern/openapi/openapi.yaml#L10139-L10142

This is via the [`data_manager_task_serializer`](https://github.com/HumanSignal/label-studio-client-generator/blob/474228b0171c5723ee418b240ac620f8a0b1121c/fern/openapi/openapi.yaml#L5967) with a reference to the `AnnotationsDmField` object 

https://github.com/HumanSignal/label-studio-client-generator/blob/81576844bd10e4320863ae93eaf50634a5bef4ca/fern/openapi/openapi.yaml#L10281-L10284

When using the `Annotation` object for items returned from `client.tasks.get()` or `client.tasks.list()` there's an error thrown due to type incompatibility for `dict` (returned type) and `int` (field definition type). The current definition for the `completed_by` field is:

```yaml
completed_by:
  title: Completed by
  type: integer
```

Which is why I believe this change _should_ fix the problem. My aim is to ensure the proposed fix from the PR referenced at the top of this summary can be made permanent.