### PR TITLE
fix: LEAP-1840: Add OpenCV dependency

### DIFF
--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -47,6 +47,7 @@ groups:
             jsonschema: '>=4.23.0'
             requests-mock: '1.12.1'
             numpy: '>=1.26.4,<3.0.0'
+            opencv-python: '^4.9.0'
             datamodel-code-generator: '0.26.1'
             jsf: '^0.11.2'
             pyjwt: '^2.10.1'


### PR DESCRIPTION
It was previously added by LEAP-1937 but then removed by the generator.