### PR TITLE
fix: BROS-197: Add missing parameters for /api/projects

### DIFF
--- a/fern/openapi/overrides.yaml
+++ b/fern/openapi/overrides.yaml
@@ -486,6 +486,64 @@ paths:
         curl -X GET https://localhost:8080/api/projects/ -H 'Authorization: Token abc123'
 
         ```
+    parameters:
+      - name: ordering
+        in: query
+        description: Which field to use when ordering the results.
+        required: false
+        schema:
+          type: string
+      - name: ids
+        in: query
+        description: ids
+        required: false
+        schema:
+          type: string
+      - name: title
+        in: query
+        description: title
+        required: false
+        schema:
+          type: string
+      - name: page
+        in: query
+        description: A page number within the paginated result set.
+        required: false
+        schema:
+          type: integer
+      - name: page_size
+        in: query
+        description: Number of results to return per page.
+        required: false
+        schema:
+          type: integer
+      - name: workspaces
+        in: query
+        description: workspaces
+        required: false
+        schema:
+          type: integer
+      - name: include
+        in: query
+        description: >
+          Comma-separated list of count fields to include in the response to optimize performance. 
+          Available fields: task_number, finished_task_number, total_predictions_number, 
+          total_annotations_number, num_tasks_with_annotations, useful_annotation_number, 
+          ground_truth_number, skipped_annotations_number. If not specified, all count fields are included.
+        required: false
+        schema:
+          type: string
+        example: "task_number,total_annotations_number,num_tasks_with_annotations"
+      - name: filter
+        in: query
+        description: >
+          Filter projects by pinned status. Use 'pinned_only' to return only pinned projects, 
+          'exclude_pinned' to return only non-pinned projects, or 'all' to return all projects.
+        required: false
+        schema:
+          type: string
+          enum: [all, pinned_only, exclude_pinned]
+          default: all
     post:
       summary: Create new project
       description: >


### PR DESCRIPTION
Enable the following function to work properly:
```python
for project in ls.projects.list(include="id,title,is_published,workspace", filter="exclude_pinned"):
   ...
```
