### PR TITLE
chore: ROOT-64: stop publishing docs on every push to master, in favor of workflow_dispatch

### DIFF
--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -1,9 +1,11 @@
 name: "Publish Docs"
 
 on:
-  push:
-    branches:
-      - master
+  # TODO(jo): uncomment when we are ready to resume publishing docs on push
+  # push:
+  #   branches:
+  #     - master
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.sha }}


### PR DESCRIPTION
Prep work for migrating to fully generated SDK