### PR TITLE
fix: ROOT-68: Add missing params discovered during SDK QA

### DIFF
--- a/fern/openapi/openapi.yaml
+++ b/fern/openapi/openapi.yaml
@@ -13710,12 +13710,8 @@ paths:
       security:
       - Token: []
       responses:
-        '201':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/LseS3ImportStorage'
-          description: ''
+        '200':
+          description: Validation successful
       x-fern-sdk-group-name:
       - import_storage
       - s3s
@@ -15476,12 +15472,53 @@ components:
         Serializer get numbers from project queryset annotation,
         make sure, that you use correct one(Project.objects.with_counts())
       properties:
-        require_comment_on_skip:
+        is_draft:
           type: boolean
-          default: false
-        queue_total:
+          description: Whether or not the project is in the middle of being created
+        skipped_annotations_number:
           type: string
           readOnly: true
+        title:
+          type: string
+          nullable: true
+          description: Project name. Must be between 3 and 50 characters long.
+          maxLength: 50
+          minLength: 3
+        review_settings:
+          $ref: '#/components/schemas/ReviewSettings'
+        custom_task_lock_ttl:
+          type: integer
+          maximum: 86400
+          minimum: 1
+          nullable: true
+          description: TTL in seconds for task reservations, on new and existing tasks
+        workspace_title:
+          type: string
+          readOnly: true
+        parsed_label_config:
+          readOnly: true
+          description: JSON-formatted labeling configuration
+        members:
+          type: string
+          readOnly: true
+        custom_script:
+          type: string
+        finished_task_number:
+          type: integer
+          readOnly: true
+        maximum_annotations:
+          type: integer
+          maximum: 2147483647
+          minimum: -2147483648
+          title: Maximum annotation number
+          description: Maximum number of annotations for one task. If the number of
+            annotations per task is equal or greater to this value, the task is completed
+            (is_labeled=True)
+        show_ground_truth_first:
+          type: boolean
+        show_instruction:
+          type: boolean
+          description: Show instructions to the annotator before they start
         control_weights:
           nullable: true
           description: 'Dict of weights for each control tag in metric calculation.
@@ -15492,251 +15529,210 @@ components:
             be twice more important than Airplaine, then you have to need the specify:
             {''my_bbox'': {''type'': ''RectangleLabels'', ''labels'': {''Car'': 1.0,
             ''Airplaine'': 0.5}, ''overall'': 0.33}'
-        reviewer_queue_total:
-          type: string
-          readOnly: true
-        enable_empty_annotation:
-          type: boolean
-          description: Allow annotators to submit empty annotations
-        workspace:
-          type: string
-          readOnly: true
-        total_annotations_number:
-          type: string
-          readOnly: true
-        parsed_label_config:
-          readOnly: true
-          description: JSON-formatted labeling configuration
-        duplication_done:
-          type: boolean
-          default: false
-        review_total_tasks:
-          type: string
-          readOnly: true
-        reveal_preannotations_interactively:
-          type: boolean
-          description: Reveal pre-annotations interactively
-        description_short:
-          type: string
-          readOnly: true
-        task_number:
+        id:
           type: integer
           readOnly: true
-          description: Total task number in project
-        custom_task_lock_ttl:
-          type: integer
-          maximum: 86400
-          minimum: 1
-          nullable: true
-          description: TTL in seconds for task reservations, on new and existing tasks
-        workspace_title:
-          type: string
-          readOnly: true
-        skip_queue:
-          nullable: true
-          oneOf:
-          - $ref: '#/components/schemas/SkipQueueEnum'
-          - $ref: '#/components/schemas/NullEnum'
-        is_published:
-          type: boolean
-          title: Published
-          description: Whether or not the project is published to annotators
-        start_training_on_annotation_update:
-          type: boolean
-          readOnly: true
-          description: Start model training after any annotations are submitted or
-            updated
-        show_annotation_history:
-          type: boolean
-          description: Show annotation history to annotator
-        show_skip_button:
-          type: boolean
-          description: Show a skip button in interface and allow annotators to skip
-            the task
-        annotation_limit_count:
-          type: integer
-          minimum: 1
-          nullable: true
-        color:
-          type: string
-          nullable: true
-          maxLength: 16
-        created_at:
-          type: string
-          format: date-time
-          readOnly: true
-        members_count:
-          type: string
-          readOnly: true
-        show_instruction:
-          type: boolean
-          description: Show instructions to the annotator before they start
-        annotator_evaluation_minimum_score:
+        annotation_limit_percent:
           type: string
           format: decimal
           pattern: ^-?\d{0,3}(?:\.\d{0,2})?$
           nullable: true
-          default: '95.00'
-        show_overlap_first:
-          type: boolean
-        show_collab_predictions:
-          type: boolean
-          title: Show predictions to annotator
-          description: If set, the annotator can view model predictions
-        evaluate_predictions_automatically:
-          type: boolean
-          description: Retrieve and display predictions when loading a task
-        queue_left:
+        reviewed_number:
+          type: string
+          readOnly: true
+        queue_done:
           type: string
           readOnly: true
         model_version:
           type: string
           nullable: true
           description: Machine learning model version
-        label_config:
-          type: string
-          nullable: true
-          description: Label config in XML format. See more about it in documentation
-        show_ground_truth_first:
-          type: boolean
-        ground_truth_number:
-          type: integer
-          readOnly: true
-          description: Honeypot annotation number in project
-        overlap_cohort_percentage:
-          type: integer
-          maximum: 2147483647
-          minimum: -2147483648
-        allow_stream:
-          type: string
-          readOnly: true
-        useful_annotation_number:
-          type: string
-          readOnly: true
-        config_has_control_tags:
-          type: boolean
-          readOnly: true
-          description: Flag to detect is project ready for labeling
-        sampling:
-          nullable: true
-          oneOf:
-          - $ref: '#/components/schemas/SamplingEnum'
-          - $ref: '#/components/schemas/NullEnum'
-        comment_classification_config:
-          type: string
         prompts:
           type: string
           readOnly: true
-        reviewed_number:
+        show_collab_predictions:
+          type: boolean
+          title: Show predictions to annotator
+          description: If set, the annotator can view model predictions
+        queue_left:
           type: string
           readOnly: true
-        maximum_annotations:
+        rejected:
+          type: string
+          readOnly: true
+        color:
+          type: string
+          nullable: true
+          maxLength: 16
+        skip_queue:
+          nullable: true
+          oneOf:
+          - $ref: '#/components/schemas/SkipQueueEnum'
+          - $ref: '#/components/schemas/NullEnum'
+        description_short:
+          type: string
+          readOnly: true
+        annotation_limit_count:
           type: integer
-          maximum: 2147483647
-          minimum: -2147483648
-          title: Maximum annotation number
-          description: Maximum number of annotations for one task. If the number of
-            annotations per task is equal or greater to this value, the task is completed
-            (is_labeled=True)
-        ready:
+          minimum: 1
+          nullable: true
+        data_types:
+          readOnly: true
+          nullable: true
+        blueprints:
+          type: array
+          items:
+            $ref: '#/components/schemas/BlueprintList'
+          readOnly: true
+        workspace:
           type: string
           readOnly: true
         duplication_status:
           type: string
-        members:
-          type: string
-          readOnly: true
         num_tasks_with_annotations:
           type: string
           readOnly: true
-        skipped_annotations_number:
+        start_training_on_annotation_update:
+          type: boolean
+          readOnly: true
+          description: Start model training after any annotations are submitted or
+            updated
+        created_by:
+          allOf:
+          - $ref: '#/components/schemas/UserSimple'
+          description: Project owner
+        task_number:
+          type: integer
+          readOnly: true
+          description: Total task number in project
+        reviewer_queue_total:
           type: string
           readOnly: true
-        is_draft:
-          type: boolean
-          description: Whether or not the project is in the middle of being created
-        annotation_limit_percent:
+        annotator_evaluation_minimum_score:
           type: string
           format: decimal
           pattern: ^-?\d{0,3}(?:\.\d{0,2})?$
           nullable: true
+          default: '95.00'
+        allow_stream:
+          type: string
+          readOnly: true
+        total_predictions_number:
+          type: integer
+          readOnly: true
+        description:
+          type: string
+          nullable: true
+          description: Project description
+        queue_total:
+          type: string
+          readOnly: true
+        comment_classification_config:
+          type: string
+        annotator_evaluation_minimum_tasks:
+          type: integer
+          minimum: 0
+          nullable: true
+          default: 10
+        is_published:
+          type: boolean
+          title: Published
+          description: Whether or not the project is published to annotators
+        total_annotations_number:
+          type: string
+          readOnly: true
+        label_config:
+          type: string
+          nullable: true
+          description: Label config in XML format. See more about it in documentation
+        members_count:
+          type: string
+          readOnly: true
         min_annotations_to_start_training:
           type: integer
           maximum: 2147483647
           minimum: -2147483648
           description: Minimum number of completed tasks after which model training
             is started
-        annotator_evaluation_minimum_tasks:
-          type: integer
-          minimum: 0
+        reveal_preannotations_interactively:
+          type: boolean
+          description: Reveal pre-annotations interactively
+        sampling:
           nullable: true
-          default: 10
-        finished_task_number:
+          oneOf:
+          - $ref: '#/components/schemas/SamplingEnum'
+          - $ref: '#/components/schemas/NullEnum'
+        overlap_cohort_percentage:
           type: integer
-          readOnly: true
-        id:
-          type: integer
-          readOnly: true
-        assignment_settings:
-          $ref: '#/components/schemas/AssignmentSettings'
-        organization:
-          type: integer
-          nullable: true
-        created_by:
-          allOf:
-          - $ref: '#/components/schemas/UserSimple'
-          description: Project owner
-        has_blueprints:
-          type: string
-          readOnly: true
-        custom_script:
-          type: string
-        blueprints:
-          type: array
-          items:
-            $ref: '#/components/schemas/BlueprintList'
-          readOnly: true
-        review_settings:
-          $ref: '#/components/schemas/ReviewSettings'
-        data_types:
-          readOnly: true
-          nullable: true
+          maximum: 2147483647
+          minimum: -2147483648
         pause_on_failed_annotator_evaluation:
           type: boolean
           nullable: true
           default: false
-        queue_done:
+        duplication_done:
+          type: boolean
+          default: false
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        useful_annotation_number:
+          type: string
+          readOnly: true
+        pinned_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: Pinned date and time
+        organization:
+          type: integer
+          nullable: true
+        ready:
+          type: string
+          readOnly: true
+        enable_empty_annotation:
+          type: boolean
+          description: Allow annotators to submit empty annotations
+        show_overlap_first:
+          type: boolean
+        expert_instruction:
+          type: string
+          nullable: true
+          description: Labeling instructions in HTML format
+        show_skip_button:
+          type: boolean
+          description: Show a skip button in interface and allow annotators to skip
+            the task
+        has_blueprints:
           type: string
           readOnly: true
         config_suitable_for_bulk_annotation:
           type: boolean
           readOnly: true
           description: Flag to detect is project ready for bulk annotation
-        description:
+        review_total_tasks:
           type: string
-          nullable: true
-          description: Project description
-        title:
-          type: string
-          nullable: true
-          description: Project name. Must be between 3 and 50 characters long.
-          maxLength: 50
-          minLength: 3
-        total_predictions_number:
+          readOnly: true
+        show_annotation_history:
+          type: boolean
+          description: Show annotation history to annotator
+        config_has_control_tags:
+          type: boolean
+          readOnly: true
+          description: Flag to detect is project ready for labeling
+        ground_truth_number:
           type: integer
           readOnly: true
-        expert_instruction:
-          type: string
-          nullable: true
-          description: Labeling instructions in HTML format
-        pinned_at:
-          type: string
-          format: date-time
-          nullable: true
-          description: Pinned date and time
-        rejected:
-          type: string
-          readOnly: true
+          description: Honeypot annotation number in project
+        require_comment_on_skip:
+          type: boolean
+          default: false
+        assignment_settings:
+          $ref: '#/components/schemas/AssignmentSettings'
+        evaluate_predictions_automatically:
+          type: boolean
+          description: Retrieve and display predictions when loading a task
       required:
       - allow_stream
       - assignment_settings


### PR DESCRIPTION
- add project param in /dm/actions
- since OpenAPI 3.0.3 doesn't allow DELETE requests with bodies, allow view delete to use query params instead
- correct the comma separated list field type to be a string, since it's used in param serializer contexts only
- add `annotation` and `draft` params to comments export endpoint
- improve types of comment_authors and similar fields on task
- s3s validate calls return empty 200s