### PR TITLE
Disable push trigger for Publish Docs workflow

### DIFF
--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -1,9 +1,10 @@
 name: "Publish Docs"
 
 on:
-  push:
-    branches:
-      - master
+  # TODO(jo): uncomment when we no longer worried about bad docs deployments
+  #   branches:
+  #     - master
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.sha }}


### PR DESCRIPTION
...because Fern previews are erroring currently